### PR TITLE
Add the ability to toggle between light and dark theme

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { NavbarComponent } from './components/navbar/navbar.component';
 import { UpdateService } from './services/update.service';
 import { FooterComponent } from './components/footer/footer.component';
+import { ThemeService } from './services/theme.service';
 
 @Component({
   selector: 'app-root',
@@ -136,12 +137,14 @@ export class AppComponent {
   showInstallPrompt = false;
   private deferredPrompt: any;
 
-  constructor(public updateService: UpdateService) {
+  constructor(public updateService: UpdateService, private themeService: ThemeService) {
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       this.deferredPrompt = e;
       this.showInstallPrompt = true;
     });
+
+    this.themeService.applyTheme();
   }
 
   async installPwa() {

--- a/src/app/components/learning/learning.component.ts
+++ b/src/app/components/learning/learning.component.ts
@@ -297,7 +297,7 @@ import { Observable, BehaviorSubject, from } from 'rxjs';
         left: 0;
         right: 0;
         z-index: 99;
-        background: rgba(255, 255, 255, 0.8);
+        background: var(--surface-color);
         backdrop-filter: blur(10px);
         box-shadow: 0 -1px 3px rgba(0, 0, 0, 0.1);
         height: 72px;
@@ -736,7 +736,7 @@ import { Observable, BehaviorSubject, from } from 'rxjs';
         left: 0;
         right: 0;
         z-index: 99;
-        background: rgba(255, 255, 255, 0.8);
+        background: var(--surface-color);
         backdrop-filter: blur(10px);
         box-shadow: 0 -1px 3px rgba(0, 0, 0, 0.1);
       }

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -38,7 +38,7 @@ import { CommonModule } from '@angular/common';
   styles: [
     `
       .navbar {
-        background: rgba(255, 255, 255, 0.8);
+        background: var(--surface-color);
         backdrop-filter: blur(10px);
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
         padding: 1rem 0; /* Changed: removed left/right padding */

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SettingsService } from '../../services/settings.service';
 import { AudioService } from '../../services/audio.service';
+import { ThemeService } from '../../services/theme.service';
 
 @Component({
   selector: 'app-settings',
@@ -34,6 +35,15 @@ import { AudioService } from '../../services/audio.service';
           [ngModel]="playbackSpeed()"
           (ngModelChange)="updatePlaybackSpeed($event)"
         />
+      </div>
+
+      <div class="setting-item">
+        <label for="theme-select">Theme:</label>
+        <select id="theme-select" [(ngModel)]="selectedTheme" (ngModelChange)="onThemeChange($event)">
+          <option value="auto">Auto</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
       </div>
 
       <div class="setting-item">
@@ -89,10 +99,12 @@ export class SettingsComponent {
   isClearingCache = signal(false);
   cacheMessage = signal('');
   cacheMessageClass = signal('');
+  selectedTheme = signal(this.themeService.getSavedTheme());
 
   constructor(
     private settingsService: SettingsService,
-    private audioService: AudioService
+    private audioService: AudioService,
+    private themeService: ThemeService
   ) {
     // Create an effect to clear the cache message
     effect(() => {
@@ -123,5 +135,9 @@ export class SettingsComponent {
     } finally {
       this.isClearingCache.set(false);
     }
+  }
+
+  onThemeChange(theme: string) {
+    this.themeService.setTheme(theme);
   }
 }

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -138,6 +138,7 @@ export class SettingsComponent {
   }
 
   onThemeChange(theme: string) {
+    this.themeService.saveTheme(theme);
     this.themeService.setTheme(theme);
   }
 }

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, signal } from '@angular/core';
+import { Component, computed, effect, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SettingsService } from '../../services/settings.service';
@@ -99,12 +99,12 @@ export class SettingsComponent {
   isClearingCache = signal(false);
   cacheMessage = signal('');
   cacheMessageClass = signal('');
+  themeService = inject(ThemeService);
+  audioService = inject(AudioService);
+  settingsService = inject(SettingsService);
   selectedTheme = signal(this.themeService.getSavedTheme());
 
   constructor(
-    private settingsService: SettingsService,
-    private audioService: AudioService,
-    private themeService: ThemeService
   ) {
     // Create an effect to clear the cache message
     effect(() => {

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -15,15 +15,20 @@ export class ThemeService {
     this.setTheme(savedTheme);
   }
 
+  saveTheme(theme: string) {
+    localStorage.setItem(this.THEME_KEY, theme);
+  }
+
   setTheme(theme: string) {
     if (theme === 'auto') {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const prefersDark = window.matchMedia(
+        '(prefers-color-scheme: dark)'
+      ).matches;
       theme = prefersDark ? 'dark' : 'light';
     }
 
     document.body.classList.remove('light-theme', 'dark-theme');
     document.body.classList.add(`${theme}-theme`);
-    localStorage.setItem(this.THEME_KEY, theme);
   }
 
   getSavedTheme(): string {

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ThemeService {
+  private readonly THEME_KEY = 'app-theme';
+
+  constructor() {
+    this.applyTheme();
+  }
+
+  applyTheme() {
+    const savedTheme = this.getSavedTheme();
+    this.setTheme(savedTheme);
+  }
+
+  setTheme(theme: string) {
+    if (theme === 'auto') {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      theme = prefersDark ? 'dark' : 'light';
+    }
+
+    document.body.classList.remove('light-theme', 'dark-theme');
+    document.body.classList.add(`${theme}-theme`);
+    localStorage.setItem(this.THEME_KEY, theme);
+  }
+
+  getSavedTheme(): string {
+    return localStorage.getItem(this.THEME_KEY) || 'auto';
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -98,3 +98,34 @@ button:hover {
     gap: 1rem;
   }
 }
+
+/* CSS variables for light and dark themes */
+:root {
+  --light-background-color: #f8fafc;
+  --light-surface-color: #ffffff;
+  --light-text-color: #1e293b;
+  --light-text-light: #64748b;
+
+  --dark-background-color: #1e293b;
+  --dark-surface-color: #2d3748;
+  --dark-text-color: #f8fafc;
+  --dark-text-light: #a0aec0;
+}
+
+/* Light theme */
+body.light-theme {
+  --background-color: var(--light-background-color);
+  --surface-color: var(--light-surface-color);
+  --text-color: var(--light-text-color);
+  --text-light: var(--light-text-light);
+  color-scheme: light;
+}
+
+/* Dark theme */
+body.dark-theme {
+  --background-color: var(--dark-background-color);
+  --surface-color: var(--dark-surface-color);
+  --text-color: var(--dark-text-color);
+  --text-light: var(--dark-text-light);
+  color-scheme: dark;
+}


### PR DESCRIPTION
Add the ability to toggle between light and dark themes and default to "Auto" theme.

* **ThemeService**: Create a new service `ThemeService` with methods `applyTheme`, `setTheme`, and `getSavedTheme` to manage theme settings and save them to localStorage.
* **AppComponent**: Import `ThemeService` and call `this.themeService.applyTheme()` in the constructor to apply the saved theme on app initialization.
* **SettingsComponent**: Add a dropdown to select theme with options "Auto", "Light", and "Dark". Bind the dropdown to a new `selectedTheme` property and call `this.themeService.setTheme(this.selectedTheme)` when the dropdown value changes.
* **CSS**: Add CSS variables for light and dark themes and CSS rules to apply the themes based on a class on the `body` element.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sondreb/polytalk/pull/3?shareId=52224c26-0883-4278-9afe-77a5cfea890d).